### PR TITLE
add a subcommand for displaying information about supported operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +979,7 @@ dependencies = [
  "arrow",
  "chrono",
  "clap",
+ "colored",
  "csv",
  "lazy_static",
  "num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "nem-mms"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nem-mms"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ num = "^0.4.0"
 scraper = "^0.12.0"
 reqwest = { version = "^0.11.8", features = ["blocking"] }
 rayon = "^1.5.1"
+colored = "^2.0.0"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Help can be sought in the usual fashion
 ```
 > nem-mms help
 
-nem-mms 0.1.2
+nem-mms 0.1.3
 mattswoon
 Fetch and parse AEMO's MMS data into parquet
 
@@ -35,6 +35,7 @@ FLAGS:
 SUBCOMMANDS:
     fetch    Fetch MMS files from Nemweb
     help     Prints this message or the help of the given subcommand(s)
+    info     Information about supported MMS packages
     parse    Parse a flat file csv or zip
 ```
 
@@ -104,6 +105,53 @@ This operation will download all files on the relevant page.
 
 ```
 > nem-mms fetch DISPATCH_UNIT_SCADA current ./downloaded_files/
+```
+
+## Info
+
+Not all packages have the same level of support - flat files can be parsed
+but fetching from the different depositories is patchy. 
+
+Fetch operations are coloured green or red on supported terminals.
+
+```
+> nem-mms DISPATCH_UNIT_SCADA
+
+Pacakge name: DISPATCH_UNIT_SCADA
+Supported fetch operations:
+        ✓ Current
+        ✓ Archive
+        ✓ Historic
+Schema:
+        Field { name: "DUID", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "SETTLEMENTDATE", data_type: Timestamp(Second, None), nullable: false, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "SCADAVALUE", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+```
+
+```
+> nem-mms info DISPATCH_NEGATIVE_RESIDUE
+
+Pacakge name: DISPATCH_NEGATIVE_RESIDUE
+Supported fetch operations:
+        ✓ Current
+        ✓ Archive
+        ✗ Historic
+Schema:
+        Field { name: "SETTLEMENTDATE", data_type: Timestamp(Second, None), nullable: false, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "NRM_DATETIME", data_type: Timestamp(Second, None), nullable: false, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "DIRECTIONAL_INTERCONNECTORID", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "NRM_ACTIVATED_FLAG", data_type: Boolean, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "CUMUL_NEGRESIDUE_AMOUNT", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "CUMUL_NEGRESIDUE_PREV_TI", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "NEGRESIDUE_CURRENT_TI", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "NEGRESIDUE_PD_NEXT_TI", data_type: Float64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "PRICE_REVISION", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "PREDISPATCHSEQNO", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "EVENT_ACTIVATED_DI", data_type: Timestamp(Second, None), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "EVENT_DEACTIVATED_DI", data_type: Timestamp(Second, None), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "DI_NOTBINDING_COUNT", data_type: Int16, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "DI_VIOLATED_COUNT", data_type: Int16, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
+        Field { name: "NRM_CONSTRAINT_BLOCKED_FLAG", data_type: Boolean, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
 ```
 
 # Todo

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,13 @@ fn main() {
                          .required_if("ARCHIVE", "historic")
                          .takes_value(true)
                          .default_value("07")))
+        .subcommand(SubCommand::with_name("info")
+                    .about("Information about supported MMS packages")
+                    .arg(Arg::with_name("PACKAGE")
+                         .help("Package type")
+                         .required(true)
+                         .takes_value(true)
+                         .possible_values(&packages::Package::available_packages())))
         .get_matches();
 
     match matches.subcommand() {
@@ -94,7 +101,14 @@ fn main() {
                 },
                 _ => panic!("Invalid ARCHIVE")
             }
-        }
+        },
+        ("info", Some(sub_m)) => {
+            let package = sub_m.value_of("PACKAGE")
+                .and_then(packages::Package::from_str)
+                .expect("Not a valid package");
+            let info = packages::PackageInfo::new(package);
+            println!("{}", info);
+        },
         _ => {}
     }
 }


### PR DESCRIPTION
`nem-mms info [PACKAGE]` displays the supported or unsupported fetch operations as well as the output parquet table schema